### PR TITLE
Externalize hard-coded user name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ ai_memory.json
 ai_script_log.txt
 ai_script_history/
 desktop_command_queue.json
+plugins/user_profile.local.json
+gui/user_profile.local.json

--- a/ai_assistant_config/assistant_identity.json
+++ b/ai_assistant_config/assistant_identity.json
@@ -3,8 +3,7 @@
   "role": "Hyper-intelligent system control assistant",
   "base_context": "Act as Igris, a state-of-the-art AI operating system in development. Be bold, efficient, precise.",
   "style": {
-    "tone": "confident, resourceful, technically fearless",
-    "audience": "Aaron"
+    "tone": "confident, resourceful, technically fearless"
   },
   "model_settings": {
     "default_model": "hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF:Q5_K_M"

--- a/cli/igris_cli_final_enhanced.py
+++ b/cli/igris_cli_final_enhanced.py
@@ -27,8 +27,20 @@ sys.path.insert(0, str(base_dir))
 import igris_core
 from igris_core import load_policy, respond_with_review, ask_ollama as _ask, run_cmd, match_intent, authenticate_admin
 
+def get_user_name() -> str:
+    profile_override = base_dir / "plugins" / "user_profile.local.json"
+    if profile_override.exists():
+        try:
+            with profile_override.open(encoding="utf-8") as f:
+                return json.load(f).get("name", "User")
+        except Exception:
+            pass
+    return os.getenv("IGRIS_USER_NAME", "User")
+
+USER_NAME = get_user_name()
+
 DEFAULT_IDENTITY = {
-    "intro_message": "Welcome back, Aaron. I'm Igris – your personal Windows control assistant. Ready to assist.",
+    "intro_message": f"Welcome back, {USER_NAME}. I'm Igris – your personal Windows control assistant. Ready to assist.",
     "fallback_behavior": {"on_no_match": "I'm not sure how to do that yet, but I'm learning."},
     "base_context": "You are Igris, an AI trained to match user requests to known Windows tasks.",
     "version": "unknown"

--- a/cli/igris_cli_merged_with_tag_patch.py
+++ b/cli/igris_cli_merged_with_tag_patch.py
@@ -27,8 +27,20 @@ sys.path.insert(0, str(base_dir))
 import igris_core
 from igris_core import load_policy, respond_with_review, ask_ollama as _ask, run_cmd, match_intent, authenticate_admin
 
+def get_user_name() -> str:
+    profile_override = base_dir / "plugins" / "user_profile.local.json"
+    if profile_override.exists():
+        try:
+            with profile_override.open(encoding="utf-8") as f:
+                return json.load(f).get("name", "User")
+        except Exception:
+            pass
+    return os.getenv("IGRIS_USER_NAME", "User")
+
+USER_NAME = get_user_name()
+
 DEFAULT_IDENTITY = {
-    "intro_message": "Welcome back, Aaron. I'm Igris – your personal Windows control assistant. Ready to assist.",
+    "intro_message": f"Welcome back, {USER_NAME}. I'm Igris – your personal Windows control assistant. Ready to assist.",
     "fallback_behavior": {"on_no_match": "I'm not sure how to do that yet, but I'm learning."},
     "base_context": "You are Igris, an AI trained to match user requests to known Windows tasks.",
     "version": "unknown"

--- a/cli/igris_cli_patched.py
+++ b/cli/igris_cli_patched.py
@@ -4,6 +4,7 @@ import json
 import re
 import shlex
 import sys
+import os
 from pathlib import Path
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
@@ -12,8 +13,20 @@ from prompt_toolkit.history import FileHistory
 import igris_core
 from igris_core import load_policy, respond_with_review, ask_ollama as _ask, run_cmd, match_intent
 
+def get_user_name() -> str:
+    profile_override = Path(__file__).resolve().parent.parent / "plugins" / "user_profile.local.json"
+    if profile_override.exists():
+        try:
+            with profile_override.open(encoding="utf-8") as f:
+                return json.load(f).get("name", "User")
+        except Exception:
+            pass
+    return os.getenv("IGRIS_USER_NAME", "User")
+
+USER_NAME = get_user_name()
+
 DEFAULT_IDENTITY = {
-    "intro_message": "Welcome back, Aaron. I'm Igris – your personal Windows control assistant. Ready to assist.",
+    "intro_message": f"Welcome back, {USER_NAME}. I'm Igris – your personal Windows control assistant. Ready to assist.",
     "fallback_behavior": {"on_no_match": "I'm not sure how to do that yet, but I'm learning."},
     "base_context": "You are Igris, an AI trained to match user requests to known Windows tasks.",
     "version": "unknown"

--- a/cli/igris_cli_plus_learn_history.py
+++ b/cli/igris_cli_plus_learn_history.py
@@ -27,8 +27,20 @@ sys.path.insert(0, str(base_dir))
 import igris_core
 from igris_core import load_policy, respond_with_review, ask_ollama as _ask, run_cmd, match_intent, authenticate_admin
 
+def get_user_name() -> str:
+    profile_override = base_dir / "plugins" / "user_profile.local.json"
+    if profile_override.exists():
+        try:
+            with profile_override.open(encoding="utf-8") as f:
+                return json.load(f).get("name", "User")
+        except Exception:
+            pass
+    return os.getenv("IGRIS_USER_NAME", "User")
+
+USER_NAME = get_user_name()
+
 DEFAULT_IDENTITY = {
-    "intro_message": "Welcome back, Aaron. I'm Igris – your personal Windows control assistant. Ready to assist.",
+    "intro_message": f"Welcome back, {USER_NAME}. I'm Igris – your personal Windows control assistant. Ready to assist.",
     "fallback_behavior": {"on_no_match": "I'm not sure how to do that yet, but I'm learning."},
     "base_context": "You are Igris, an AI trained to match user requests to known Windows tasks.",
     "version": "unknown"

--- a/gui/user_profile.json
+++ b/gui/user_profile.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aaron",
+  "name": "User",
   "plugin_history": {
     "run_security_audit": {
       "count": 1,

--- a/igris_phase3_patch_20250810_224424/ai_assistant_config/assistant_identity.json
+++ b/igris_phase3_patch_20250810_224424/ai_assistant_config/assistant_identity.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "voice_enabled": true,
   "auto_execute": false,
-  "intro_message": "Welcome back, Aaron. I'm Igris \u2014 your personal Windows control assistant. Ready to assist.",
+  "intro_message": "Welcome back, USER_NAME. I'm Igris \u2014 your personal Windows control assistant. Ready to assist.",
   "personality": {
     "tone": "Confident, professional, direct.",
     "style": "Concise and precise. Avoid small talk unless asked.",

--- a/plugins/generate_live_topology_map.py
+++ b/plugins/generate_live_topology_map.py
@@ -6,6 +6,7 @@ Generate Live Topology Map Plugin
 """
 import tkinter as tk
 import random
+import os
 import matplotlib.pyplot as plt
 # --- Import dependent plugins ---
 try:
@@ -17,7 +18,10 @@ except ImportError:
         print("[WARN] network_scanner not found. Using simulated data.")
         return [
             {'ip': '192.168.1.1', 'hostname': 'Gateway'},
-            {'ip': '192.168.1.101', 'hostname': 'Aarons-PC'},
+            {
+                'ip': '192.168.1.101',
+                'hostname': os.getenv("IGRIS_SAMPLE_HOSTNAME", "user-pc")
+            },
             {'ip': '192.168.1.152', 'hostname': 'smart-tv.local'},
         ]
 

--- a/plugins/learn_user_routines.py
+++ b/plugins/learn_user_routines.py
@@ -1,5 +1,5 @@
 """
-Learns Aaron's Routines Plugin
+Learn User's Routines Plugin
 - Analyzes plugin execution history from ai_memory.json.
 - Identifies the most frequently used tools and suggests potential automations.
 """

--- a/plugins/user_profile.json
+++ b/plugins/user_profile.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aaron",
+  "name": "User",
   "voice_enabled": true,
   "preferred_browser": "Edge",
   "preferred_editor": "Notepad++",


### PR DESCRIPTION
## Summary
- remove user-specific "audience" field from assistant identity
- load user name from optional local profile or environment variable in CLI tools
- replace Aaron-specific data in configs and plugins with placeholders

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'igris_cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b8d3de01348320a561d25e55c0ccb8