### PR TITLE
Add mom and dad sections to gift registry

### DIFF
--- a/web/gift_registry/README.md
+++ b/web/gift_registry/README.md
@@ -1,0 +1,20 @@
+# Family Gift Registry
+
+A lightweight, single-page gift registry crafted especially for organizing thoughtful surprises for mom, dad, and the kids.
+
+## Features
+- ✨ Curated inspiration section with filters for mom, dad, the kids, and gift types
+- ✅ Interactive wishlist that tracks purchased items, budgets, and notes
+- ➕ Form to add personalized gift ideas (saved locally in the browser)
+- 🗓️ Planner timeline with upcoming celebrations and automatic countdown
+
+## Getting started
+This is a static website. To view it, open `index.html` in your browser or serve the folder with any static file server. For example:
+
+```bash
+python -m http.server --directory web/gift_registry 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) in your browser.
+
+Your custom gifts are stored in `localStorage`, so they stay on the device you're using. Use the **Reset to starter list** button to restore the original ideas.

--- a/web/gift_registry/README.md
+++ b/web/gift_registry/README.md
@@ -1,9 +1,9 @@
 # Family Gift Registry
 
-A lightweight, single-page gift registry crafted especially for organizing thoughtful surprises for mom, dad, and the kids.
+A lightweight, single-page gift registry crafted especially for organizing thoughtful surprises for my wife and kids.
 
 ## Features
-- ✨ Curated inspiration section with filters for mom, dad, the kids, and gift types
+- ✨ Curated inspiration section with filters for my wife, the kids, and gift types
 - ✅ Interactive wishlist that tracks purchased items, budgets, and notes
 - ➕ Form to add personalized gift ideas (saved locally in the browser)
 - 🗓️ Planner timeline with upcoming celebrations and automatic countdown

--- a/web/gift_registry/index.html
+++ b/web/gift_registry/index.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Family Gift Registry</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Playfair+Display:wght@500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <noscript>
+    <div class="no-script">This gift registry uses a bit of JavaScript for saving items. Please enable JavaScript for the full experience.</div>
+  </noscript>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">🎁</span>
+        <span class="brand-text">Family Gift Registry</span>
+      </div>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="#featured">Ideas</a>
+        <a href="#wishlist">Wishlist</a>
+        <a href="#planner">Planner</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="home">
+      <div class="container hero__content">
+        <div class="hero__intro">
+          <p class="hero__eyebrow">Made with love for my favorite people</p>
+          <h1>Your curated hub for thoughtful surprises</h1>
+          <p class="hero__lead">
+            Keep every gift idea in one beautiful place. From cozy mornings for mom to gadget upgrades for dad and adventure kits
+            for the kids, this registry keeps track of what they love, what's already wrapped, and the big days coming up.
+          </p>
+          <div class="hero__cta">
+            <a class="btn btn--primary" href="#wishlist">Plan the next surprise</a>
+            <a class="btn" href="#featured">Browse inspiration</a>
+          </div>
+        </div>
+        <aside class="hero__highlights" aria-label="Family snapshot">
+          <article class="highlight-card">
+            <h2>Family Highlights</h2>
+            <ul>
+              <li><strong>Anniversary getaway</strong> booked for May 24</li>
+              <li><strong>STEM camp</strong> wishlist open for summer</li>
+              <li>Every purchase tracked so nothing gets doubled</li>
+            </ul>
+            <p class="note">Tip: mark gifts as purchased to update the countdown stats instantly.</p>
+          </article>
+          <article class="countdown-card" aria-live="polite">
+            <h3>Upcoming Celebrations</h3>
+            <div class="countdown" data-countdown>
+              <div>
+                <span class="countdown__value" data-countdown-days>--</span>
+                <span class="countdown__label">days</span>
+              </div>
+              <div>
+                <span class="countdown__value" data-countdown-hours>--</span>
+                <span class="countdown__label">hours</span>
+              </div>
+              <div>
+                <span class="countdown__value" data-countdown-minutes>--</span>
+                <span class="countdown__label">mins</span>
+              </div>
+            </div>
+            <p class="countdown-card__event">Next: Family picnic &amp; surprise scavenger hunt</p>
+          </article>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section section--light" id="featured">
+      <div class="container">
+        <header class="section__header">
+          <div>
+            <p class="section__eyebrow">Curated ideas</p>
+            <h2>Thoughtful gifts for the crew that makes my heart full</h2>
+          </div>
+          <div class="filters" role="toolbar" aria-label="Filter gift ideas">
+            <button class="filter-btn is-active" data-filter="all">All</button>
+            <button class="filter-btn" data-filter="mom">For mom</button>
+            <button class="filter-btn" data-filter="dad">For dad</button>
+            <button class="filter-btn" data-filter="kids">For the kids</button>
+            <button class="filter-btn" data-filter="experience">Experience</button>
+            <button class="filter-btn" data-filter="keepsake">Keepsake</button>
+            <button class="filter-btn" data-filter="learning">Learning</button>
+          </div>
+        </header>
+
+        <div class="card-grid" data-featured-grid>
+          <article class="gift-card" data-groups="mom experience">
+            <div class="gift-card__tag">Weekend Escape</div>
+            <h3>Mountaintop Cabin Weekend</h3>
+            <p>Two nights at a quiet cabin with a private hot tub, chef-prepared meals, and a photo session to capture the memories.</p>
+            <div class="gift-card__meta">
+              <span>$540</span>
+              <a href="https://www.getaway.house" target="_blank" rel="noopener">View inspiration</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="mom keepsake">
+            <div class="gift-card__tag">Keepsake</div>
+            <h3>Custom Family Story Necklace</h3>
+            <p>Hand-stamped necklace featuring milestone charms chosen by the kids. Comes with a note from each child tucked in the box.</p>
+            <div class="gift-card__meta">
+              <span>$120</span>
+              <a href="https://www.etsy.com" target="_blank" rel="noopener">Shop styles</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="mom experience">
+            <div class="gift-card__tag">Mindful Moment</div>
+            <h3>At-Home Spa &amp; Story Night</h3>
+            <p>A basket of spa treats, a handwritten playlist, and the kids reading their favorite bedtime story while candles glow.</p>
+            <div class="gift-card__meta">
+              <span>$85</span>
+              <a href="https://www.uncommongoods.com" target="_blank" rel="noopener">Build the set</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="dad experience">
+            <div class="gift-card__tag">Quality Time</div>
+            <h3>Workshop Day with Dad</h3>
+            <p>Reserve a woodworking studio so each kid can build a keepsake alongside dad, followed by a celebratory lunch voucher.</p>
+            <div class="gift-card__meta">
+              <span>$95</span>
+              <a href="https://www.rockler.com/in-store-events" target="_blank" rel="noopener">Reserve a spot</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="dad keepsake">
+            <div class="gift-card__tag">Everyday Joy</div>
+            <h3>Custom Sketch Travel Mug</h3>
+            <p>Insulated mug printed with the kids' doodles and a hidden message inside the lid to brighten his morning commute.</p>
+            <div class="gift-card__meta">
+              <span>$48</span>
+              <a href="https://www.shutterfly.com" target="_blank" rel="noopener">Create yours</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="kids learning">
+            <div class="gift-card__tag">STEM Fun</div>
+            <h3>Rocket Lab Afternoon</h3>
+            <p>Build-your-own rocket launcher kit followed by a backyard launch party complete with mission badges and cocoa.</p>
+            <div class="gift-card__meta">
+              <span>$65</span>
+              <a href="https://www.kiwico.com" target="_blank" rel="noopener">Explore kits</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="kids keepsake">
+            <div class="gift-card__tag">Memory Maker</div>
+            <h3>Adventure Scrapbook Starter</h3>
+            <p>A bundle of instant film, blank comic panels, and colorful washi tapes so the kids can document every adventure.</p>
+            <div class="gift-card__meta">
+              <span>$48</span>
+              <a href="https://www.artscow.com" target="_blank" rel="noopener">Grab supplies</a>
+            </div>
+          </article>
+
+          <article class="gift-card" data-groups="kids experience">
+            <div class="gift-card__tag">Family Time</div>
+            <h3>Twilight Backyard Movie Night</h3>
+            <p>Projector rental, homemade popcorn bar, glow sticks, and a vote on the feature film so every kid feels like the director.</p>
+            <div class="gift-card__meta">
+              <span>$110</span>
+              <a href="https://www.funflicks.com" target="_blank" rel="noopener">Plan it</a>
+            </div>
+          </article>
+        </div>
+        <p class="section__note">Use the filters to focus on just mom, dad, the kids, or a type of gift experience.</p>
+      </div>
+    </section>
+
+    <section class="section" id="wishlist">
+      <div class="container">
+        <header class="section__header">
+          <div>
+            <p class="section__eyebrow">Personalized list</p>
+            <h2>Track everything from wishlists to wrapped surprises</h2>
+          </div>
+          <p class="section__lead">Add new ideas, mark gifts as purchased, and keep an eye on the budget &mdash; all saved to this browser so I can pick up right where I left off.</p>
+        </header>
+
+        <div class="dashboard" role="status" aria-live="polite">
+          <div class="dashboard__stat">
+            <span class="dashboard__value" data-stat-total>0</span>
+            <span class="dashboard__label">Total gifts</span>
+          </div>
+          <div class="dashboard__stat">
+            <span class="dashboard__value" data-stat-purchased>0</span>
+            <span class="dashboard__label">Purchased</span>
+          </div>
+          <div class="dashboard__stat">
+            <span class="dashboard__value" data-stat-remaining>0</span>
+            <span class="dashboard__label">Still to find</span>
+          </div>
+          <div class="dashboard__stat">
+            <span class="dashboard__value" data-stat-budget>$0</span>
+            <span class="dashboard__label">Estimated spend</span>
+          </div>
+        </div>
+
+        <div class="wishlist-layout">
+          <div class="wishlist__columns">
+            <section class="wishlist__column" aria-labelledby="mom-list-title">
+              <div class="column__header">
+                <h3 id="mom-list-title">For Mom</h3>
+                <span class="column__count" data-count-mom>0 items</span>
+              </div>
+              <ul class="gift-list" data-recipient-list="mom"></ul>
+            </section>
+            <section class="wishlist__column" aria-labelledby="dad-list-title">
+              <div class="column__header">
+                <h3 id="dad-list-title">For Dad</h3>
+                <span class="column__count" data-count-dad>0 items</span>
+              </div>
+              <ul class="gift-list" data-recipient-list="dad"></ul>
+            </section>
+            <section class="wishlist__column" aria-labelledby="kids-list-title">
+              <div class="column__header">
+                <h3 id="kids-list-title">For The Kids</h3>
+                <span class="column__count" data-count-kids>0 items</span>
+              </div>
+              <ul class="gift-list" data-recipient-list="kids"></ul>
+            </section>
+          </div>
+
+          <aside class="gift-form-card" aria-labelledby="gift-form-title">
+            <h3 id="gift-form-title">Add a gift idea</h3>
+            <p class="gift-form-card__lead">Jot down new surprises as they pop into my head. Everything stays local to this device.</p>
+            <form id="gift-form" autocomplete="off">
+              <div class="field-group">
+                <label for="gift-name">Gift name</label>
+                <input id="gift-name" name="name" type="text" required placeholder="Ex: StoryWorth subscription" />
+              </div>
+              <div class="field-grid">
+                <div class="field-group">
+                  <label for="gift-recipient">Recipient</label>
+                  <select id="gift-recipient" name="recipient" required>
+                    <option value="mom">Mom</option>
+                    <option value="dad">Dad</option>
+                    <option value="kids">One of the kids</option>
+                  </select>
+                </div>
+                <div class="field-group">
+                  <label for="gift-category">Category</label>
+                  <select id="gift-category" name="category" required>
+                    <option value="experience">Experience</option>
+                    <option value="keepsake">Keepsake</option>
+                    <option value="learning">Learning</option>
+                    <option value="creative">Creative</option>
+                    <option value="wellness">Wellness</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field-grid">
+                <div class="field-group">
+                  <label for="gift-price">Estimated price ($)</label>
+                  <input id="gift-price" name="price" type="number" min="0" step="1" placeholder="75" />
+                </div>
+                <div class="field-group">
+                  <label for="gift-priority">Priority</label>
+                  <select id="gift-priority" name="priority">
+                    <option value="High">High</option>
+                    <option value="Medium" selected>Medium</option>
+                    <option value="Low">Low</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field-group">
+                <label for="gift-link">Link or store note</label>
+                <input id="gift-link" name="link" type="url" placeholder="https://" />
+              </div>
+              <div class="field-group">
+                <label for="gift-notes">Personal notes</label>
+                <textarea id="gift-notes" name="notes" rows="3" placeholder="Add a reminder, size, or the reason they'll love it"></textarea>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="btn btn--primary">Add to registry</button>
+                <button type="button" class="btn btn--ghost" id="reset-registry">Reset to starter list</button>
+              </div>
+            </form>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--light" id="planner">
+      <div class="container planner">
+        <header class="section__header">
+          <div>
+            <p class="section__eyebrow">Planning ahead</p>
+            <h2>Milestones &amp; moments already on the calendar</h2>
+          </div>
+          <p class="section__lead">These dates keep me on track so every celebration for mom, dad, and the kids feels intentional and joyful.</p>
+        </header>
+
+        <div class="timeline">
+          <article class="timeline__item">
+            <div class="timeline__date">May 24</div>
+            <div class="timeline__content">
+              <h3>Anniversary Weekend</h3>
+              <p>Finalize the surprise breakfast menu, pack the kids' notes, and confirm the sunset photo session.</p>
+            </div>
+          </article>
+          <article class="timeline__item">
+            <div class="timeline__date">June 15</div>
+            <div class="timeline__content">
+              <h3>Summer Adventure Day</h3>
+              <p>Kids choose between the rocket lab or the backyard movie night. Prepare supplies a week ahead.</p>
+            </div>
+          </article>
+          <article class="timeline__item">
+            <div class="timeline__date">August 03</div>
+            <div class="timeline__content">
+              <h3>Back-to-School Pep Rally</h3>
+              <p>Create personalized encouragement kits with new notebooks, a secret note, and favorite snacks.</p>
+            </div>
+          </article>
+          <article class="timeline__item">
+            <div class="timeline__date">December 18</div>
+            <div class="timeline__content">
+              <h3>Family Story Night</h3>
+              <p>Gather the scrapbook updates, record audio messages, and unveil the next year's adventure jar.</p>
+            </div>
+          </article>
+        </div>
+
+        <aside class="planner__aside" aria-label="Helpful planning tips">
+          <h3>Little reminders</h3>
+          <ul>
+            <li>Capture reactions with short voice memos for the memory box.</li>
+            <li>Let the kids help wrap gifts to build anticipation.</li>
+            <li>Balance big wow moments with smaller weekly delights.</li>
+            <li>Revisit the registry before paydays to stay on budget.</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container site-footer__content">
+      <p>Handcrafted with love &mdash; because celebrating mom, dad, and the kids is my favorite hobby.</p>
+      <p class="site-footer__note">This registry saves information only on this device. Clear your browser storage if you ever want a fresh slate.</p>
+    </div>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/web/gift_registry/index.html
+++ b/web/gift_registry/index.html
@@ -34,8 +34,8 @@
           <p class="hero__eyebrow">Made with love for my favorite people</p>
           <h1>Your curated hub for thoughtful surprises</h1>
           <p class="hero__lead">
-            Keep every gift idea in one beautiful place. From cozy mornings for mom to gadget upgrades for dad and adventure kits
-            for the kids, this registry keeps track of what they love, what's already wrapped, and the big days coming up.
+            Keep every gift idea in one beautiful place. From cozy mornings for my wife to adventure kits for the kids, this
+            registry keeps track of what they love, what's already wrapped, and the big days coming up.
           </p>
           <div class="hero__cta">
             <a class="btn btn--primary" href="#wishlist">Plan the next surprise</a>
@@ -83,8 +83,7 @@
           </div>
           <div class="filters" role="toolbar" aria-label="Filter gift ideas">
             <button class="filter-btn is-active" data-filter="all">All</button>
-            <button class="filter-btn" data-filter="mom">For mom</button>
-            <button class="filter-btn" data-filter="dad">For dad</button>
+            <button class="filter-btn" data-filter="wife">For my wife</button>
             <button class="filter-btn" data-filter="kids">For the kids</button>
             <button class="filter-btn" data-filter="experience">Experience</button>
             <button class="filter-btn" data-filter="keepsake">Keepsake</button>
@@ -93,7 +92,7 @@
         </header>
 
         <div class="card-grid" data-featured-grid>
-          <article class="gift-card" data-groups="mom experience">
+          <article class="gift-card" data-groups="wife experience">
             <div class="gift-card__tag">Weekend Escape</div>
             <h3>Mountaintop Cabin Weekend</h3>
             <p>Two nights at a quiet cabin with a private hot tub, chef-prepared meals, and a photo session to capture the memories.</p>
@@ -103,7 +102,7 @@
             </div>
           </article>
 
-          <article class="gift-card" data-groups="mom keepsake">
+          <article class="gift-card" data-groups="wife keepsake">
             <div class="gift-card__tag">Keepsake</div>
             <h3>Custom Family Story Necklace</h3>
             <p>Hand-stamped necklace featuring milestone charms chosen by the kids. Comes with a note from each child tucked in the box.</p>
@@ -113,7 +112,7 @@
             </div>
           </article>
 
-          <article class="gift-card" data-groups="mom experience">
+          <article class="gift-card" data-groups="wife wellness experience">
             <div class="gift-card__tag">Mindful Moment</div>
             <h3>At-Home Spa &amp; Story Night</h3>
             <p>A basket of spa treats, a handwritten playlist, and the kids reading their favorite bedtime story while candles glow.</p>
@@ -123,23 +122,23 @@
             </div>
           </article>
 
-          <article class="gift-card" data-groups="dad experience">
-            <div class="gift-card__tag">Quality Time</div>
-            <h3>Workshop Day with Dad</h3>
-            <p>Reserve a woodworking studio so each kid can build a keepsake alongside dad, followed by a celebratory lunch voucher.</p>
+          <article class="gift-card" data-groups="kids experience">
+            <div class="gift-card__tag">Family Project</div>
+            <h3>Backyard Makers' Day</h3>
+            <p>Transform the patio into a mini makerspace with loaner tools so the kids can craft keepsakes together while I guide the fun.</p>
             <div class="gift-card__meta">
               <span>$95</span>
-              <a href="https://www.rockler.com/in-store-events" target="_blank" rel="noopener">Reserve a spot</a>
+              <a href="https://www.rockler.com/in-store-events" target="_blank" rel="noopener">Plan the workshop</a>
             </div>
           </article>
 
-          <article class="gift-card" data-groups="dad keepsake">
+          <article class="gift-card" data-groups="wife keepsake">
             <div class="gift-card__tag">Everyday Joy</div>
-            <h3>Custom Sketch Travel Mug</h3>
-            <p>Insulated mug printed with the kids' doodles and a hidden message inside the lid to brighten his morning commute.</p>
+            <h3>Custom Love Notes Journal</h3>
+            <p>Hand-bound journal printed with the kids' doodles and hidden messages from me so she starts each morning smiling.</p>
             <div class="gift-card__meta">
               <span>$48</span>
-              <a href="https://www.shutterfly.com" target="_blank" rel="noopener">Create yours</a>
+              <a href="https://www.shutterfly.com" target="_blank" rel="noopener">Design one</a>
             </div>
           </article>
 
@@ -173,7 +172,7 @@
             </div>
           </article>
         </div>
-        <p class="section__note">Use the filters to focus on just mom, dad, the kids, or a type of gift experience.</p>
+        <p class="section__note">Use the filters to focus on just my wife, the kids, or a type of gift experience.</p>
       </div>
     </section>
 
@@ -208,19 +207,12 @@
 
         <div class="wishlist-layout">
           <div class="wishlist__columns">
-            <section class="wishlist__column" aria-labelledby="mom-list-title">
+            <section class="wishlist__column" aria-labelledby="wife-list-title">
               <div class="column__header">
-                <h3 id="mom-list-title">For Mom</h3>
-                <span class="column__count" data-count-mom>0 items</span>
+                <h3 id="wife-list-title">For My Wife</h3>
+                <span class="column__count" data-count-wife>0 items</span>
               </div>
-              <ul class="gift-list" data-recipient-list="mom"></ul>
-            </section>
-            <section class="wishlist__column" aria-labelledby="dad-list-title">
-              <div class="column__header">
-                <h3 id="dad-list-title">For Dad</h3>
-                <span class="column__count" data-count-dad>0 items</span>
-              </div>
-              <ul class="gift-list" data-recipient-list="dad"></ul>
+              <ul class="gift-list" data-recipient-list="wife"></ul>
             </section>
             <section class="wishlist__column" aria-labelledby="kids-list-title">
               <div class="column__header">
@@ -243,8 +235,7 @@
                 <div class="field-group">
                   <label for="gift-recipient">Recipient</label>
                   <select id="gift-recipient" name="recipient" required>
-                    <option value="mom">Mom</option>
-                    <option value="dad">Dad</option>
+                    <option value="wife">My wife</option>
                     <option value="kids">One of the kids</option>
                   </select>
                 </div>
@@ -298,7 +289,7 @@
             <p class="section__eyebrow">Planning ahead</p>
             <h2>Milestones &amp; moments already on the calendar</h2>
           </div>
-          <p class="section__lead">These dates keep me on track so every celebration for mom, dad, and the kids feels intentional and joyful.</p>
+          <p class="section__lead">These dates keep me on track so every celebration for my wife and the kids feels intentional and joyful.</p>
         </header>
 
         <div class="timeline">
@@ -347,7 +338,7 @@
 
   <footer class="site-footer">
     <div class="container site-footer__content">
-      <p>Handcrafted with love &mdash; because celebrating mom, dad, and the kids is my favorite hobby.</p>
+      <p>Handcrafted with love &mdash; because celebrating my wife and the kids is my favorite hobby.</p>
       <p class="site-footer__note">This registry saves information only on this device. Clear your browser storage if you ever want a fresh slate.</p>
     </div>
   </footer>

--- a/web/gift_registry/script.js
+++ b/web/gift_registry/script.js
@@ -1,12 +1,12 @@
 (function () {
   "use strict";
 
-  const storageKey = "family-gift-registry-v1";
+  const storageKey = "family-gift-registry-v2";
   const defaultGifts = [
     {
-      id: "gift-m-1",
+      id: "gift-w-1",
       name: "Sunrise coffee tasting basket",
-      recipient: "mom",
+      recipient: "wife",
       category: "wellness",
       priority: "High",
       price: 95,
@@ -16,9 +16,9 @@
       added: "2024-01-12T09:00:00.000Z"
     },
     {
-      id: "gift-m-2",
+      id: "gift-w-2",
       name: "StoryWorth subscription",
-      recipient: "mom",
+      recipient: "wife",
       category: "keepsake",
       priority: "Medium",
       price: 99,
@@ -28,28 +28,16 @@
       added: "2024-02-02T18:30:00.000Z"
     },
     {
-      id: "gift-d-1",
-      name: "Backyard grill masterclass",
-      recipient: "dad",
+      id: "gift-w-3",
+      name: "Moonlit rooftop picnic kit",
+      recipient: "wife",
       category: "experience",
       priority: "Medium",
-      price: 85,
-      link: "https://www.surlatable.com/classes",
-      notes: "Reserve a Saturday when the whole family can be sous-chefs.",
+      price: 110,
+      link: "https://www.simplesatchel.com",
+      notes: "Pack her favorite tapas, string lights, and a new playlist for slow dancing under the stars.",
       purchased: false,
-      added: "2024-04-14T17:45:00.000Z"
-    },
-    {
-      id: "gift-d-2",
-      name: "Custom engraved multitool",
-      recipient: "dad",
-      category: "keepsake",
-      priority: "High",
-      price: 72,
-      link: "https://www.etsy.com/listing/228412732",
-      notes: "Engrave the kids' initials on the handle before gifting.",
-      purchased: false,
-      added: "2024-02-22T11:15:00.000Z"
+      added: "2024-03-14T17:45:00.000Z"
     },
     {
       id: "gift-k-1",
@@ -74,10 +62,22 @@
       notes: "Add markers that match their favorite heroes.",
       purchased: false,
       added: "2024-01-28T21:10:00.000Z"
+    },
+    {
+      id: "gift-k-3",
+      name: "Backyard astronomy night",
+      recipient: "kids",
+      category: "learning",
+      priority: "High",
+      price: 60,
+      link: "https://www.exploratoriumstore.com",
+      notes: "Set up a telescope, print constellation maps, and wrap a cozy blanket for stargazing.",
+      purchased: false,
+      added: "2024-02-18T20:05:00.000Z"
     }
   ];
 
-  const recipients = ["mom", "dad", "kids"];
+  const recipients = ["wife", "kids"];
 
   const lists = Object.fromEntries(
     recipients.map((key) => [key, document.querySelector(`[data-recipient-list="${key}"]`)])
@@ -99,13 +99,24 @@
   })();
 
   function normalizeRecipient(value) {
-    if (value === "dad") {
-      return "dad";
+    const normalized = String(value || "").toLowerCase();
+    switch (normalized) {
+      case "wife":
+      case "mom":
+      case "spouse":
+        return "wife";
+      case "kid":
+      case "kids":
+      case "child":
+      case "children":
+      case "son":
+      case "daughter":
+        return "kids";
+      case "dad":
+        return "kids";
+      default:
+        return "kids";
     }
-    if (value === "mom" || value === "wife") {
-      return "mom";
-    }
-    return "kids";
   }
 
   const statEls = {

--- a/web/gift_registry/script.js
+++ b/web/gift_registry/script.js
@@ -1,0 +1,460 @@
+(function () {
+  "use strict";
+
+  const storageKey = "family-gift-registry-v1";
+  const defaultGifts = [
+    {
+      id: "gift-m-1",
+      name: "Sunrise coffee tasting basket",
+      recipient: "mom",
+      category: "wellness",
+      priority: "High",
+      price: 95,
+      link: "https://www.craftcoffee.com",
+      notes: "Include her favorite Ethiopian roast and a handwritten playlist for the tasting.",
+      purchased: false,
+      added: "2024-01-12T09:00:00.000Z"
+    },
+    {
+      id: "gift-m-2",
+      name: "StoryWorth subscription",
+      recipient: "mom",
+      category: "keepsake",
+      priority: "Medium",
+      price: 99,
+      link: "https://www.storyworth.com",
+      notes: "Pair with a new fountain pen from the kids.",
+      purchased: true,
+      added: "2024-02-02T18:30:00.000Z"
+    },
+    {
+      id: "gift-d-1",
+      name: "Backyard grill masterclass",
+      recipient: "dad",
+      category: "experience",
+      priority: "Medium",
+      price: 85,
+      link: "https://www.surlatable.com/classes",
+      notes: "Reserve a Saturday when the whole family can be sous-chefs.",
+      purchased: false,
+      added: "2024-04-14T17:45:00.000Z"
+    },
+    {
+      id: "gift-d-2",
+      name: "Custom engraved multitool",
+      recipient: "dad",
+      category: "keepsake",
+      priority: "High",
+      price: 72,
+      link: "https://www.etsy.com/listing/228412732",
+      notes: "Engrave the kids' initials on the handle before gifting.",
+      purchased: false,
+      added: "2024-02-22T11:15:00.000Z"
+    },
+    {
+      id: "gift-k-1",
+      name: "Junior chef Saturday",
+      recipient: "kids",
+      category: "experience",
+      priority: "High",
+      price: 55,
+      link: "https://www.peterspantry.com/classes",
+      notes: "Pick a recipe each child can lead. Capture a video taste test!",
+      purchased: false,
+      added: "2024-03-05T15:20:00.000Z"
+    },
+    {
+      id: "gift-k-2",
+      name: "Personalized comic book kit",
+      recipient: "kids",
+      category: "creative",
+      priority: "Medium",
+      price: 42,
+      link: "https://www.etsy.com/listing/1297619652",
+      notes: "Add markers that match their favorite heroes.",
+      purchased: false,
+      added: "2024-01-28T21:10:00.000Z"
+    }
+  ];
+
+  const recipients = ["mom", "dad", "kids"];
+
+  const lists = Object.fromEntries(
+    recipients.map((key) => [key, document.querySelector(`[data-recipient-list="${key}"]`)])
+  );
+
+  const countLabels = Object.fromEntries(
+    recipients.map((key) => [key, document.querySelector(`[data-count-${key}]`)])
+  );
+
+  const hasLocalStorage = (() => {
+    try {
+      const testKey = "__gift_registry_test__";
+      window.localStorage.setItem(testKey, "1");
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  })();
+
+  function normalizeRecipient(value) {
+    if (value === "dad") {
+      return "dad";
+    }
+    if (value === "mom" || value === "wife") {
+      return "mom";
+    }
+    return "kids";
+  }
+
+  const statEls = {
+    total: document.querySelector("[data-stat-total]"),
+    purchased: document.querySelector("[data-stat-purchased]"),
+    remaining: document.querySelector("[data-stat-remaining]"),
+    budget: document.querySelector("[data-stat-budget]")
+  };
+
+  const form = document.getElementById("gift-form");
+  const resetButton = document.getElementById("reset-registry");
+
+  let gifts = loadGifts();
+
+  function loadGifts() {
+    if (!hasLocalStorage) {
+      return defaultGifts.map((gift) => enhanceGift(gift));
+    }
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        return defaultGifts.map((gift) => enhanceGift(gift));
+      }
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return defaultGifts.map((gift) => enhanceGift(gift));
+      }
+      return parsed.map(enhanceGift);
+    } catch (error) {
+      console.warn("Gift registry storage could not be read, restoring defaults.", error);
+      return defaultGifts.map((gift) => enhanceGift(gift));
+    }
+  }
+
+  function enhanceGift(gift) {
+    return {
+      id: String(gift.id || cryptoRandomId()),
+      name: gift.name || "Untitled gift",
+      recipient: normalizeRecipient(gift.recipient),
+      category: gift.category || "experience",
+      priority: gift.priority || "Medium",
+      price: normalizePrice(gift.price),
+      link: gift.link || "",
+      notes: gift.notes || "",
+      purchased: Boolean(gift.purchased),
+      added: gift.added || new Date().toISOString()
+    };
+  }
+
+  function normalizePrice(value) {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : null;
+    }
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function cryptoRandomId() {
+    if (window.crypto && window.crypto.randomUUID) {
+      return window.crypto.randomUUID();
+    }
+    return `gift-${Math.random().toString(16).slice(2, 10)}`;
+  }
+
+  function persistGifts() {
+    if (!hasLocalStorage) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(gifts));
+    } catch (error) {
+      console.warn("Unable to save gift registry", error);
+    }
+  }
+
+  function formatCurrency(value) {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      return "N/A";
+    }
+    try {
+      return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+    } catch (error) {
+      return `$${value.toFixed(2)}`;
+    }
+  }
+
+  function renderLists() {
+    const grouped = {};
+    recipients.forEach((key) => {
+      grouped[key] = [];
+    });
+
+    for (const gift of gifts) {
+      const recipient = normalizeRecipient(gift.recipient);
+      if (!grouped[recipient]) {
+        grouped[recipient] = [];
+      }
+      grouped[recipient].push(gift);
+    }
+
+    recipients.forEach((recipient) => {
+      const recipientList = grouped[recipient] || [];
+      recipientList.sort(sortByPurchasedThenPriority);
+      updateList(lists[recipient], recipientList);
+      if (countLabels[recipient]) {
+        countLabels[recipient].textContent = summaryText(recipientList.length);
+      }
+    });
+  }
+
+  const priorityWeight = { High: 0, Medium: 1, Low: 2 };
+
+  function sortByPurchasedThenPriority(a, b) {
+    if (a.purchased !== b.purchased) {
+      return a.purchased ? 1 : -1;
+    }
+    const weightA = priorityWeight[a.priority] ?? 1;
+    const weightB = priorityWeight[b.priority] ?? 1;
+    if (weightA !== weightB) {
+      return weightA - weightB;
+    }
+    return new Date(a.added).getTime() - new Date(b.added).getTime();
+  }
+
+  function summaryText(count) {
+    if (count === 0) {
+      return "No items yet";
+    }
+    return `${count} ${count === 1 ? "item" : "items"}`;
+  }
+
+  function updateList(listElement, items) {
+    if (!listElement) {
+      return;
+    }
+    listElement.innerHTML = "";
+    if (!items.length) {
+      const empty = document.createElement("li");
+      empty.className = "gift-item gift-item--empty";
+      empty.textContent = "Add the first idea to get started.";
+      listElement.append(empty);
+      return;
+    }
+
+    for (const gift of items) {
+      const item = document.createElement("li");
+      item.className = "gift-item";
+      if (gift.purchased) {
+        item.classList.add("gift-item--purchased");
+      }
+
+      const header = document.createElement("div");
+      header.className = "gift-item__header";
+
+      const name = document.createElement("span");
+      name.className = "gift-item__name";
+      name.textContent = gift.name;
+
+      const badge = document.createElement("span");
+      badge.className = "gift-item__badge";
+      badge.textContent = `${gift.priority} priority`;
+
+      header.append(name, badge);
+
+      const meta = document.createElement("div");
+      meta.className = "gift-item__meta";
+
+      const category = document.createElement("span");
+      category.innerHTML = `<span aria-hidden="true">🏷️</span>${gift.category}`;
+      meta.append(category);
+
+      if (typeof gift.price === "number" && !Number.isNaN(gift.price)) {
+        const price = document.createElement("span");
+        price.innerHTML = `<span aria-hidden="true">💰</span>${formatCurrency(gift.price)}`;
+        meta.append(price);
+      }
+
+      const added = document.createElement("span");
+      const addedDate = new Date(gift.added);
+      const friendlyDate = !Number.isNaN(addedDate.getTime())
+        ? addedDate.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+        : "Recently added";
+      added.innerHTML = `<span aria-hidden="true">🗓️</span>${friendlyDate}`;
+      meta.append(added);
+
+      const actions = document.createElement("div");
+      actions.className = "gift-item__actions";
+
+      const toggleBtn = document.createElement("button");
+      toggleBtn.type = "button";
+      toggleBtn.className = "toggle-purchased";
+      toggleBtn.textContent = gift.purchased ? "Purchased" : "Mark purchased";
+      if (gift.purchased) {
+        toggleBtn.classList.add("is-complete");
+      }
+      toggleBtn.addEventListener("click", () => {
+        gift.purchased = !gift.purchased;
+        persistGifts();
+        render();
+      });
+      actions.append(toggleBtn);
+
+      if (gift.link) {
+        const link = document.createElement("a");
+        link.href = gift.link;
+        link.target = "_blank";
+        link.rel = "noopener";
+        link.textContent = "Open link";
+        actions.append(link);
+      }
+
+      if (gift.notes) {
+        const notes = document.createElement("p");
+        notes.className = "gift-item__notes";
+        notes.textContent = gift.notes;
+        item.append(header, meta, notes, actions);
+      } else {
+        item.append(header, meta, actions);
+      }
+
+      listElement.append(item);
+    }
+  }
+
+  function updateStats() {
+    const total = gifts.length;
+    const purchased = gifts.filter((gift) => gift.purchased).length;
+    const budget = gifts.reduce((sum, gift) => (typeof gift.price === "number" ? sum + gift.price : sum), 0);
+    statEls.total.textContent = total;
+    statEls.purchased.textContent = purchased;
+    statEls.remaining.textContent = Math.max(total - purchased, 0);
+    statEls.budget.textContent = formatCurrency(budget);
+  }
+
+  function render() {
+    renderLists();
+    updateStats();
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const name = formData.get("name").trim();
+    if (!name) {
+      return;
+    }
+
+    const newGift = enhanceGift({
+      id: cryptoRandomId(),
+      name,
+      recipient: formData.get("recipient"),
+      category: formData.get("category"),
+      priority: formData.get("priority"),
+      price: normalizePrice(formData.get("price")),
+      link: (formData.get("link") || "").trim(),
+      notes: (formData.get("notes") || "").trim(),
+      purchased: false,
+      added: new Date().toISOString()
+    });
+
+    gifts.unshift(newGift);
+    persistGifts();
+    render();
+    form.reset();
+    form.querySelector("[name='name']").focus();
+  }
+
+  function handleReset() {
+    const confirmed = window.confirm("Reset the registry to the starter list? This clears any custom items saved on this device.");
+    if (!confirmed) {
+      return;
+    }
+    gifts = defaultGifts.map((gift) => enhanceGift(gift));
+    persistGifts();
+    render();
+  }
+
+  function setupFeaturedFilters() {
+    const filterButtons = document.querySelectorAll(".filter-btn");
+    const cards = document.querySelectorAll("[data-featured-grid] .gift-card");
+
+    function applyFilter(group) {
+      cards.forEach((card) => {
+        const groups = (card.dataset.groups || "").split(/\s+/);
+        const show = group === "all" || groups.includes(group);
+        card.style.display = show ? "flex" : "none";
+      });
+    }
+
+    filterButtons.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        filterButtons.forEach((button) => button.classList.remove("is-active"));
+        btn.classList.add("is-active");
+        applyFilter(btn.dataset.filter || "all");
+      });
+    });
+
+    const activeButton = document.querySelector(".filter-btn.is-active");
+    applyFilter(activeButton?.dataset.filter || "all");
+  }
+
+  function setupCountdown() {
+    const countdownRoot = document.querySelector("[data-countdown]");
+    if (!countdownRoot) {
+      return;
+    }
+
+    const dayEl = countdownRoot.querySelector("[data-countdown-days]");
+    const hourEl = countdownRoot.querySelector("[data-countdown-hours]");
+    const minuteEl = countdownRoot.querySelector("[data-countdown-minutes]");
+
+    function nextEventDate() {
+      const now = new Date();
+      const target = new Date(now.getFullYear(), 4, 24, 9, 0, 0); // May 24, 9 AM
+      if (target.getTime() <= now.getTime()) {
+        target.setFullYear(target.getFullYear() + 1);
+      }
+      return target;
+    }
+
+    let targetDate = nextEventDate();
+
+    function tick() {
+      const now = new Date();
+      if (now.getTime() >= targetDate.getTime()) {
+        targetDate = nextEventDate();
+      }
+      const diff = targetDate.getTime() - now.getTime();
+      const minutes = Math.floor(diff / (1000 * 60));
+      const days = Math.floor(minutes / (60 * 24));
+      const hours = Math.floor((minutes - days * 24 * 60) / 60);
+      const remainingMinutes = minutes % 60;
+      dayEl.textContent = String(days).padStart(2, "0");
+      hourEl.textContent = String(hours).padStart(2, "0");
+      minuteEl.textContent = String(remainingMinutes).padStart(2, "0");
+    }
+
+    tick();
+    setInterval(tick, 60000);
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  resetButton.addEventListener("click", handleReset);
+
+  setupFeaturedFilters();
+  setupCountdown();
+  render();
+})();

--- a/web/gift_registry/styles.css
+++ b/web/gift_registry/styles.css
@@ -1,0 +1,714 @@
+:root {
+  --bg: #fcf9f4;
+  --bg-light: #ffffff;
+  --bg-highlight: #f7f0ff;
+  --text: #312a2a;
+  --text-light: #5f5a5a;
+  --accent: #d97706;
+  --accent-2: #7c3aed;
+  --accent-soft: rgba(124, 58, 237, 0.1);
+  --border: #e6ded2;
+  --success: #1d976c;
+  --shadow: 0 22px 45px rgba(29, 18, 53, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --transition: all 0.28s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "DM Sans", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  font-family: "Playfair Display", "DM Sans", serif;
+  margin: 0;
+  color: #20161f;
+}
+
+p {
+  margin: 0;
+  color: var(--text-light);
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.no-script {
+  margin: 0;
+  padding: 1rem;
+  background: #fffbeb;
+  color: #92400e;
+  text-align: center;
+}
+
+.container {
+  width: min(1080px, calc(100% - 3rem));
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(252, 249, 244, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(230, 222, 210, 0.7);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0.25rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  font-weight: 700;
+  gap: 0.6rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  font-size: 1.5rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 600;
+}
+
+.site-nav a {
+  color: var(--text);
+  text-decoration: none;
+  position: relative;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.site-nav a:focus-visible,
+.site-nav a:hover {
+  color: var(--accent-2);
+}
+
+.site-nav a:focus-visible::after,
+.site-nav a:hover::after {
+  transform: scaleX(1);
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+  background: radial-gradient(circle at 12% 25%, rgba(255, 223, 186, 0.5), transparent 55%),
+    radial-gradient(circle at 90% 0%, rgba(124, 58, 237, 0.18), transparent 60%), var(--bg);
+}
+
+.hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.hero__intro h1 {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin-bottom: 1rem;
+}
+
+.hero__lead {
+  font-size: 1.05rem;
+  max-width: 36ch;
+}
+
+.hero__cta {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  flex-wrap: wrap;
+}
+
+.hero__highlights {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.highlight-card,
+.countdown-card {
+  background: var(--bg-light);
+  padding: 1.8rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.highlight-card ul {
+  margin: 0.8rem 0 1rem;
+  padding-left: 1.1rem;
+  color: var(--text);
+}
+
+.highlight-card li + li {
+  margin-top: 0.4rem;
+}
+
+.note {
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.countdown {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.countdown__value {
+  display: block;
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--accent-2);
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section--light {
+  background: #fff9f2;
+}
+
+.section__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.section__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.section__lead {
+  max-width: 46ch;
+}
+
+.section__note {
+  margin-top: 2rem;
+  font-size: 0.92rem;
+  color: var(--text-light);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filter-btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  background: rgba(124, 58, 237, 0.08);
+  color: var(--accent-2);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.filter-btn:hover,
+.filter-btn:focus-visible {
+  border-color: rgba(124, 58, 237, 0.35);
+  background: rgba(124, 58, 237, 0.18);
+}
+
+.filter-btn.is-active {
+  background: var(--accent-2);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 10px 26px rgba(124, 58, 237, 0.25);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.8rem;
+}
+
+.gift-card {
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid rgba(124, 58, 237, 0.08);
+  box-shadow: var(--shadow);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.gift-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 40px rgba(28, 17, 66, 0.12);
+}
+
+.gift-card__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(217, 119, 6, 0.1);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.82rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.gift-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.gift-card__meta a {
+  color: var(--accent-2);
+  text-decoration: none;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.2rem;
+  margin-bottom: 2.5rem;
+}
+
+.dashboard__stat {
+  background: var(--bg-light);
+  padding: 1.4rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.dashboard__value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent-2);
+}
+
+.dashboard__label {
+  font-size: 0.95rem;
+}
+
+.wishlist-layout {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.wishlist__columns {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.wishlist__column {
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  padding: 1.8rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.column__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.column__count {
+  font-size: 0.9rem;
+  color: var(--text-light);
+}
+
+.gift-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.gift-item {
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(124, 58, 237, 0.1);
+  background: linear-gradient(140deg, rgba(124, 58, 237, 0.05), rgba(217, 119, 6, 0.04));
+  display: grid;
+  gap: 0.75rem;
+}
+
+.gift-item--empty {
+  text-align: center;
+  font-style: italic;
+  color: var(--text-light);
+  background: rgba(124, 58, 237, 0.06);
+  border: 1px dashed rgba(124, 58, 237, 0.2);
+}
+
+.gift-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.gift-item__name {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.gift-item__badge {
+  background: rgba(217, 119, 6, 0.16);
+  color: var(--accent);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.gift-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-light);
+}
+
+.gift-item__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.gift-item__notes {
+  font-size: 0.9rem;
+  color: var(--text-light);
+}
+
+.gift-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.gift-item__actions a {
+  color: var(--accent-2);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.toggle-purchased {
+  background: rgba(29, 151, 108, 0.15);
+  color: var(--success);
+  border: 1px solid rgba(29, 151, 108, 0.4);
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: var(--transition);
+}
+
+.toggle-purchased:hover,
+.toggle-purchased:focus-visible {
+  background: rgba(29, 151, 108, 0.25);
+}
+
+.toggle-purchased.is-complete {
+  background: rgba(29, 151, 108, 0.12);
+  border-color: rgba(29, 151, 108, 0.45);
+  color: var(--success);
+}
+
+.gift-item--purchased {
+  opacity: 0.72;
+}
+
+.gift-item--purchased .gift-item__name {
+  text-decoration: line-through;
+}
+
+.gift-form-card {
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 6.5rem;
+}
+
+.gift-form-card__lead {
+  margin-bottom: 1.5rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  padding: 0.6rem 0.8rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: #fff;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent-2);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--accent-2);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: rgba(124, 58, 237, 0.22);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(124, 58, 237, 0.32);
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  filter: brightness(1.05);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: rgba(124, 58, 237, 0.35);
+  color: var(--accent-2);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.planner {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 2.5rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline__item {
+  display: grid;
+  grid-template-columns: minmax(0, 120px) minmax(0, 1fr);
+  gap: 1.5rem;
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  border: 1px solid rgba(124, 58, 237, 0.1);
+  box-shadow: var(--shadow);
+}
+
+.timeline__date {
+  font-weight: 700;
+  color: var(--accent-2);
+  font-size: 1.1rem;
+}
+
+.planner__aside {
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  padding: 1.8rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.planner__aside ul {
+  margin: 1rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--text-light);
+}
+
+.site-footer {
+  background: #1c1235;
+  color: rgba(255, 255, 255, 0.88);
+  padding: 3rem 0;
+}
+
+.site-footer__content {
+  display: grid;
+  gap: 0.8rem;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.site-footer__note {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 960px) {
+  .hero__content {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__intro {
+    text-align: center;
+  }
+
+  .hero__lead {
+    margin: 0 auto;
+  }
+
+  .hero__cta {
+    justify-content: center;
+  }
+
+  .hero__highlights {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .planner {
+    grid-template-columns: 1fr;
+  }
+
+  .gift-form-card {
+    position: static;
+  }
+
+  .wishlist-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-nav {
+    display: none;
+  }
+
+  .section {
+    padding: 3.5rem 0;
+  }
+
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline__item {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 540px) {
+  .container {
+    width: calc(100% - 2rem);
+  }
+
+  .dashboard {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- retune featured inspiration and site copy to highlight gifts for mom, dad, and the kids
- expand the wishlist dashboard and starter data so mom and dad each have dedicated lists alongside the kids
- adjust layout styling and documentation to reflect the broader family coverage

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa0d2584483209a4370152a96decd